### PR TITLE
commit modified version bugfix/#7

### DIFF
--- a/src/common/DoRequest.ts
+++ b/src/common/DoRequest.ts
@@ -8,6 +8,8 @@ import { systemLogger } from './logging';
 import AppError from './AppError';
 import Config from '../common/Config';
 const Message = Config.ReadConfig('./config/message.json');
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
 /* eslint-enable */
 
 /**


### PR DESCRIPTION
# pullrequestタイトル
node18からipv6が優先することに伴いlocalhostの通信に失敗する。

# 概要
## 環境（UT実行バージョン）
- postgres: 15.6
```
$ psql --version
psql (PostgreSQL) 15.6
```
- node: v18.16.0
```
$ fnm use 18
Using Node v18.16.0
```

## 対処内容
- nodejsの通信をipv6優先→ipv4優先に修正した。
- src/common/DoRequest.ts内で以下を追記し、ipv4を優先して利用する設定を入れた。
```
const dns = require('dns');
dns.setDefaultResultOrder('ipv4first');
```

# コマンド実行結果
## npm install実行結果
```
$ npm install
npm WARN deprecated @types/helmet@4.0.0: This is a stub types definition. helmet p
rovides its own type definitions, so you do not need this installed.
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This prop
osal has been merged to the ECMAScript standard and thus this plugin is no longer
maintained. Please use @babel/plugin-transform-export-namespace-from instead.
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older ver
sions may use Math.random() in certain circumstances, which is known to be problem
atic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://githu
b.com/request/request/issues/3142

added 985 packages, and audited 986 packages in 3m

155 packages are looking for funding
  run `npm fund` for details

2 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

```

## ビルド実行結果
```
$ npm run build

> binary-manage-service@1.0.0 build
> npm-run-all -s lint build:ts


> binary-manage-service@1.0.0 lint
> eslint ./src/index.ts src/**/*.ts


> binary-manage-service@1.0.0 build:ts
> node ./node_modules/typescript/bin/tsc

```

## UT実行結果
```
$ npm run test:unit

> binary-manage-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.c
onfig.js

 PASS  src/tests/04-01.Upload.spec.ts (47.447 s)
 PASS  src/tests/06-01.DownloadEnd.spec.ts
 PASS  src/tests/05-01.DownloadStart.spec.ts
 PASS  src/tests/02-01.UploadEnd.spec.ts
 PASS  src/tests/01-01.UploadStart.spec.ts
 PASS  src/tests/08-01.Download.spec.ts
 PASS  src/tests/09-01.GetBinaryManage.spec.ts
 PASS  src/tests/07-01.DownloadCancel.spec.ts
 PASS  src/tests/03-01.UploadCancel.spec.ts
 PASS  src/tests/10-01.DeleteBinaryManage.spec.ts
 PASS  src/tests/04-02.Upload.dbInsertError.spec.ts
 PASS  src/tests/10-02.DeleteBinaryManage.dbUpdateError.spec.ts
 PASS  src/tests/05-02.DownloadStart.dbUpdateError.spec.ts
 PASS  src/tests/03-02.UploadCancel.dbUpdateError.spec.ts
 PASS  src/tests/01-02.UploadStart.dbInsertError.spec.ts (5.666 s)
 PASS  src/tests/07-02.DownloadCancel.dbUpdateError.spec.ts
---------------------|---------|----------|---------|---------|-------------------
File                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------|---------|----------|---------|---------|-------------------
All files            |     100 |      100 |     100 |     100 |
 repositories        |     100 |      100 |     100 |     100 |
  EntityOperation.ts |     100 |      100 |     100 |     100 |
 resources           |     100 |      100 |     100 |     100 |
  ...geController.ts |     100 |      100 |     100 |     100 |
  ...adController.ts |     100 |      100 |     100 |     100 |
  ...adController.ts |     100 |      100 |     100 |     100 |
 services            |     100 |      100 |     100 |     100 |
  ...anageService.ts |     100 |      100 |     100 |     100 |
  DownloadService.ts |     100 |      100 |     100 |     100 |
  OperatorService.ts |     100 |      100 |     100 |     100 |
  UploadService.ts   |     100 |      100 |     100 |     100 |
---------------------|---------|----------|---------|---------|-------------------

Test Suites: 16 passed, 16 total
Tests:       126 passed, 126 total
Snapshots:   0 total
Time:        107.046 s
Ran all test suites.

```